### PR TITLE
Add H264 Compression ISPE25 Vedant Saran and Nikita (see description)

### DIFF
--- a/protos/cakelab/arflow_grpc/v1/xr_cpu_image.proto
+++ b/protos/cakelab/arflow_grpc/v1/xr_cpu_image.proto
@@ -14,14 +14,15 @@ message XRCpuImage {
     // @exclude The number in each field should match the enum XRCpuImage.Format for more convenient conversion.
     FORMAT_ANDROID_YUV_420_888 = 1;
     FORMAT_IOS_YP_CBCR_420_8BI_PLANAR_FULL_RANGE = 2;
-    // @exclude FORMAT_ONECOMPONENT8 = 3;
+    FORMAT_ONECOMPONENT8 = 3;
     FORMAT_DEPTHFLOAT32 = 4; /// iOS
     FORMAT_DEPTHUINT16 = 5; /// Android
-    // @exclude FORMAT_ONECOMPONENT32 = 6;
-    // @exclude FORMAT_ARGB32 = 7;
-    // @exclude FORMAT_RGBA32 = 8;
-    // @exclude FORMAT_BGRA32 = 9;
-    // @exclude FORMAT_RGB24 = 10;
+    FORMAT_ONECOMPONENT32 = 6;
+    FORMAT_ARGB32 = 7;
+    FORMAT_RGBA32 = 8;
+    FORMAT_BGRA32 = 9;
+    FORMAT_RGB24 = 10;
+    FORMAT_H264RGB24 = 16;
   }
 
   /// https://docs.unity3d.com/Packages/com.unity.xr.arfoundation@6.0/api/UnityEngine.XR.ARSubsystems.XRCpuImage.Plane.html

--- a/python/arflow/_core.py
+++ b/python/arflow/_core.py
@@ -160,6 +160,7 @@ class ARFlowServicer(arflow_service_pb2_grpc.ARFlowServiceServicer):
             raise NotFound("Session not found")
 
         rr.disconnect(session_stream.stream)
+        session_stream.terminate()
         logger.info("Deleted session: %s", session_stream.info)
 
         self.on_delete_session(session_stream=session_stream)
@@ -241,6 +242,7 @@ class ARFlowServicer(arflow_service_pb2_grpc.ARFlowServiceServicer):
 
         try:
             session_stream.info.devices.remove(request.device)
+            session_stream.remove_device(request.device)
         except ValueError:
             raise NotFound("Device not in session")
 
@@ -274,7 +276,6 @@ class ARFlowServicer(arflow_service_pb2_grpc.ARFlowServiceServicer):
             raise InvalidArgument("No frames provided")
 
         session_stream = self._get_session_stream(request.session_id.value)
-
         if request.device not in session_stream.info.devices:
             raise NotFound("Device not in session")
 

--- a/python/arflow/_session_stream.py
+++ b/python/arflow/_session_stream.py
@@ -58,6 +58,8 @@ class SessionStream:
         """Session information."""
         self.stream = stream
         """Stream handle to the Rerun recording associated with this session."""
+
+        """Maps for stremaing processes associated with chunked data"""
         self.streaming_pipes: dict[str, subprocess.Popen] = {}
         self.stops: dict[str, bool] = {}
         self.decoder_threads: dict[str, threading.Thread] = {} #ffmpeg pipe needs to be kept empty so that it does not corrupt
@@ -67,7 +69,36 @@ class SessionStream:
         self.frame_chunk_queues: dict[str, queue.Queue] = {}
         self.device_intervals: dict[str, float] = {}
 
+    def remove_device(self, device: Device):
+        """Remove a device from the session stream."""
+        if device.uid in self.streaming_pipes:
+            self.stops[device.uid] = True
+            self.streaming_pipes[device.uid].stdin.close()
+            self.streaming_pipes[device.uid].stdout.close()
+            self.streaming_pipes[device.uid].wait()
+            self.decoder_threads[device.uid].join()
+            self.rerun_writers[device.uid].join()
+            del self.streaming_pipes[device.uid]
+            del self.stops[device.uid]
+            del self.decoder_threads[device.uid]
+            del self.rerun_writers[device.uid]
+            del self.image_queues[device.uid]
+            del self.timestamp_queues[device.uid]
+            del self.frame_chunk_queues[device.uid]
+            del self.device_intervals[device.uid]
+
+    def terminate(self):
+        """Terminate all streaming processes and threads."""
+        for device in self.streaming_pipes.keys():
+            self.stops[device] = True
+            self.streaming_pipes[device].stdin.close()
+            self.streaming_pipes[device].stdout.close()
+            self.streaming_pipes[device].wait()
+            self.decoder_threads[device].join()
+            self.rerun_writers[device].join()
+
     def decoder_thread(self, device: Device, width:int, height:int):
+        """Thread to decode the video stream from the ffmpeg pipe."""
         while not self.stops[device.uid]:
             raw = self.streaming_pipes[device.uid].stdout.read(height*width*3)
             if not raw:
@@ -75,6 +106,11 @@ class SessionStream:
             frame = np.frombuffer(raw, dtype=np.uint8)
             self.image_queues[device.uid].put(frame)
     def rerun_writer(self, device: Device, width:int, height:int):
+        """
+        Thread to write the decoded frames to the Rerun stream.
+        Tries to approximate correct frame timestamp based on the number of frames in the chunk and device's interval
+        """
+        
         # currently theres no real way to transfer an array of timestamps, and I don't want to modify the entire API
         # so frame timestamps are approximated by chunk
         # timestamp_chunk + device_interval/num_frames_in_chunk (where device interval is in seconds)
@@ -85,13 +121,11 @@ class SessionStream:
         print(cur_num_frames_in_batch)
         #i dunno what any of this is, just copying from the main save color frames
         while not self.stops[device.uid]:
-            print("hi")
             # also make sure that they always have a value, and to use the older frames time approximation if needed
-            if (cur_num_frames_processed >= cur_num_frames_in_batch and not self.timestamp_queues[device.uid].empty()):
-                cur_base_timestamp = self.timestamp_queues[device.uid].get()
-                cur_num_frames_processed = cur_num_frames_processed - cur_num_frames_in_batch 
-                cur_num_frames_in_batch = self.frame_chunk_queues[device.uid].get()
-
+            if (cur_num_frames_processed >= cur_num_frames_in_batch):
+                cur_base_timestamp = self.timestamp_queues[device.uid].get(block=True, timeout=None)
+                cur_num_frames_processed = 0 
+                cur_num_frames_in_batch = self.frame_chunk_queues[device.uid].get(block=True, timeout=None)
             entity_path = rr.new_entity_path(
                 [
                     f"{self.info.metadata.name}_{self.info.id.value}",
@@ -114,18 +148,23 @@ class SessionStream:
                 static=True,
                 recording=self.stream,
             )
+            # print(cur_base_timestamp.seconds + cur_base_timestamp.nanos / 1e9 + cur_num_frames_processed * self.device_intervals[device.uid] / cur_num_frames_in_batch)
             rr.send_columns(
                 entity_path,
                 times=[
                     rr.TimeSecondsColumn(
                         timeline=Timeline.DEVICE,
                         times=[
-                            0 #cur_base_timestamp + cur_num_frames_processed * self.device_intervals[device.uid] / cur_num_frames_in_batch
+                            cur_base_timestamp.seconds + cur_base_timestamp.nanos / 1e9 + cur_num_frames_processed * self.device_intervals[device.uid] / cur_num_frames_in_batch
+                            #cur_base_timestamp + cur_num_frames_processed * self.device_intervals[device.uid] / cur_num_frames_in_batch
                         ],
                     ),
                     rr.TimeSecondsColumn(
                         timeline=Timeline.IMAGE,
-                        times=[0], #cur_base_timestamp + cur_num_frames_processed * self.device_intervals[device.uid] / cur_num_frames_in_batch
+                        times=[
+                            cur_base_timestamp.seconds + cur_base_timestamp.nanos / 1e9 + cur_num_frames_processed * self.device_intervals[device.uid] / cur_num_frames_in_batch
+                            #cur_base_timestamp + cur_num_frames_processed * self.device_intervals[device.uid] / cur_num_frames_in_batch
+                               ], 
                     ),
                 ],
                 components=[
@@ -136,7 +175,14 @@ class SessionStream:
                 ],
                 recording=self.stream.to_native(),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
             )
-            sleep(self.device_intervals[device.uid]/cur_num_frames_in_batch)
+            cur_num_frames_processed += 1
+            
+            #optional delay to allow for smoothing on rerun's display video feed
+            #can comment out if needed
+            frame_based = self.device_intervals[device.uid]/cur_num_frames_in_batch
+            queue_size_based = 2 / self.image_queues[device.uid].qsize() if self.image_queues[device.uid].qsize() > 0 else 1000
+            sleep(min(frame_based, queue_size_based))  # sleep for smooth frames, choosing either frame based (based on what # of frames given or queue size in case behind)
+            
 
     def save_transform_frames(
         self,
@@ -231,6 +277,9 @@ class SessionStream:
                 )
                 data = np.array([_to_i420_format(f.image) for f in homogenous_frames])
             elif format == 10:
+                """
+                Decode a frame in RGB format and display it
+                """
                 format_static = rr.components.ImageFormat(
                     width=width,
                     height=height,
@@ -242,11 +291,18 @@ class SessionStream:
                     for f in homogenous_frames
                 ])
             elif format == 16:
+                """
+                Decode a frame in H264 format 
+                Create ffmpeg process/thread if none exists
+                Insert data into appropriate queues and other dictionary based variables
+                indexed on device uid for utilization by threads
+                """
                 for f in homogenous_frames:
                     if device.uid not in self.streaming_pipes:
                         self.image_queues[device.uid] = queue.Queue()
                         self.timestamp_queues[device.uid] = queue.Queue()
                         self.frame_chunk_queues[device.uid] = queue.Queue()
+                    print(f.device_timestamp)
                     self.timestamp_queues[device.uid].put(f.device_timestamp) #for now # of frames in the chunk is stored in row stride field
                     self.frame_chunk_queues[device.uid].put(f.image.planes[0].row_stride)
                     if device.uid not in self.streaming_pipes:

--- a/python/cakelab/arflow_grpc/v1/xr_cpu_image_pb2.py
+++ b/python/cakelab/arflow_grpc/v1/xr_cpu_image_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from cakelab.arflow_grpc.v1 import vector2_int_pb2 as cakelab_dot_arflow__grpc_dot_v1_dot_vector2__int__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n)cakelab/arflow_grpc/v1/xr_cpu_image.proto\x12\x16\x63\x61kelab.arflow_grpc.v1\x1a(cakelab/arflow_grpc/v1/vector2_int.proto\"\xf8\x03\n\nXRCpuImage\x12\x42\n\ndimensions\x18\x01 \x01(\x0b\x32\".cakelab.arflow_grpc.v1.Vector2IntR\ndimensions\x12\x41\n\x06\x66ormat\x18\x02 \x01(\x0e\x32).cakelab.arflow_grpc.v1.XRCpuImage.FormatR\x06\x66ormat\x12\x1c\n\ttimestamp\x18\x03 \x01(\x01R\ttimestamp\x12@\n\x06planes\x18\x04 \x03(\x0b\x32(.cakelab.arflow_grpc.v1.XRCpuImage.PlaneR\x06planes\x1a]\n\x05Plane\x12\x1d\n\nrow_stride\x18\x01 \x01(\x05R\trowStride\x12!\n\x0cpixel_stride\x18\x02 \x01(\x05R\x0bpixelStride\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\x0cR\x04\x64\x61ta\"\xa3\x01\n\x06\x46ormat\x12\x16\n\x12\x46ORMAT_UNSPECIFIED\x10\x00\x12\x1e\n\x1a\x46ORMAT_ANDROID_YUV_420_888\x10\x01\x12\x30\n,FORMAT_IOS_YP_CBCR_420_8BI_PLANAR_FULL_RANGE\x10\x02\x12\x17\n\x13\x46ORMAT_DEPTHFLOAT32\x10\x04\x12\x16\n\x12\x46ORMAT_DEPTHUINT16\x10\x05\x42\xa4\x01\n\x1a\x63om.cakelab.arflow_grpc.v1B\x0fXrCpuImageProtoP\x01\xa2\x02\x03\x43\x41X\xaa\x02\x16\x43\x61keLab.ARFlow.Grpc.V1\xca\x02\x15\x43\x61kelab\\ArflowGrpc\\V1\xe2\x02!Cakelab\\ArflowGrpc\\V1\\GPBMetadata\xea\x02\x17\x43\x61kelab::ArflowGrpc::V1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n)cakelab/arflow_grpc/v1/xr_cpu_image.proto\x12\x16\x63\x61kelab.arflow_grpc.v1\x1a(cakelab/arflow_grpc/v1/vector2_int.proto\"\x8e\x05\n\nXRCpuImage\x12\x42\n\ndimensions\x18\x01 \x01(\x0b\x32\".cakelab.arflow_grpc.v1.Vector2IntR\ndimensions\x12\x41\n\x06\x66ormat\x18\x02 \x01(\x0e\x32).cakelab.arflow_grpc.v1.XRCpuImage.FormatR\x06\x66ormat\x12\x1c\n\ttimestamp\x18\x03 \x01(\x01R\ttimestamp\x12@\n\x06planes\x18\x04 \x03(\x0b\x32(.cakelab.arflow_grpc.v1.XRCpuImage.PlaneR\x06planes\x1a]\n\x05Plane\x12\x1d\n\nrow_stride\x18\x01 \x01(\x05R\trowStride\x12!\n\x0cpixel_stride\x18\x02 \x01(\x05R\x0bpixelStride\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\x0cR\x04\x64\x61ta\"\xb9\x02\n\x06\x46ormat\x12\x16\n\x12\x46ORMAT_UNSPECIFIED\x10\x00\x12\x1e\n\x1a\x46ORMAT_ANDROID_YUV_420_888\x10\x01\x12\x30\n,FORMAT_IOS_YP_CBCR_420_8BI_PLANAR_FULL_RANGE\x10\x02\x12\x18\n\x14\x46ORMAT_ONECOMPONENT8\x10\x03\x12\x17\n\x13\x46ORMAT_DEPTHFLOAT32\x10\x04\x12\x16\n\x12\x46ORMAT_DEPTHUINT16\x10\x05\x12\x19\n\x15\x46ORMAT_ONECOMPONENT32\x10\x06\x12\x11\n\rFORMAT_ARGB32\x10\x07\x12\x11\n\rFORMAT_RGBA32\x10\x08\x12\x11\n\rFORMAT_BGRA32\x10\t\x12\x10\n\x0c\x46ORMAT_RGB24\x10\n\x12\x14\n\x10\x46ORMAT_H264RGB24\x10\x10\x42\xa4\x01\n\x1a\x63om.cakelab.arflow_grpc.v1B\x0fXrCpuImageProtoP\x01\xa2\x02\x03\x43\x41X\xaa\x02\x16\x43\x61keLab.ARFlow.Grpc.V1\xca\x02\x15\x43\x61kelab\\ArflowGrpc\\V1\xe2\x02!Cakelab\\ArflowGrpc\\V1\\GPBMetadata\xea\x02\x17\x43\x61kelab::ArflowGrpc::V1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -34,9 +34,9 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\032com.cakelab.arflow_grpc.v1B\017XrCpuImageProtoP\001\242\002\003CAX\252\002\026CakeLab.ARFlow.Grpc.V1\312\002\025Cakelab\\ArflowGrpc\\V1\342\002!Cakelab\\ArflowGrpc\\V1\\GPBMetadata\352\002\027Cakelab::ArflowGrpc::V1'
   _globals['_XRCPUIMAGE']._serialized_start=112
-  _globals['_XRCPUIMAGE']._serialized_end=616
+  _globals['_XRCPUIMAGE']._serialized_end=766
   _globals['_XRCPUIMAGE_PLANE']._serialized_start=357
   _globals['_XRCPUIMAGE_PLANE']._serialized_end=450
   _globals['_XRCPUIMAGE_FORMAT']._serialized_start=453
-  _globals['_XRCPUIMAGE_FORMAT']._serialized_end=616
+  _globals['_XRCPUIMAGE_FORMAT']._serialized_end=766
 # @@protoc_insertion_point(module_scope)

--- a/python/cakelab/arflow_grpc/v1/xr_cpu_image_pb2.pyi
+++ b/python/cakelab/arflow_grpc/v1/xr_cpu_image_pb2.pyi
@@ -14,13 +14,27 @@ class XRCpuImage(_message.Message):
         FORMAT_UNSPECIFIED: _ClassVar[XRCpuImage.Format]
         FORMAT_ANDROID_YUV_420_888: _ClassVar[XRCpuImage.Format]
         FORMAT_IOS_YP_CBCR_420_8BI_PLANAR_FULL_RANGE: _ClassVar[XRCpuImage.Format]
+        FORMAT_ONECOMPONENT8: _ClassVar[XRCpuImage.Format]
         FORMAT_DEPTHFLOAT32: _ClassVar[XRCpuImage.Format]
         FORMAT_DEPTHUINT16: _ClassVar[XRCpuImage.Format]
+        FORMAT_ONECOMPONENT32: _ClassVar[XRCpuImage.Format]
+        FORMAT_ARGB32: _ClassVar[XRCpuImage.Format]
+        FORMAT_RGBA32: _ClassVar[XRCpuImage.Format]
+        FORMAT_BGRA32: _ClassVar[XRCpuImage.Format]
+        FORMAT_RGB24: _ClassVar[XRCpuImage.Format]
+        FORMAT_H264RGB24: _ClassVar[XRCpuImage.Format]
     FORMAT_UNSPECIFIED: XRCpuImage.Format
     FORMAT_ANDROID_YUV_420_888: XRCpuImage.Format
     FORMAT_IOS_YP_CBCR_420_8BI_PLANAR_FULL_RANGE: XRCpuImage.Format
+    FORMAT_ONECOMPONENT8: XRCpuImage.Format
     FORMAT_DEPTHFLOAT32: XRCpuImage.Format
     FORMAT_DEPTHUINT16: XRCpuImage.Format
+    FORMAT_ONECOMPONENT32: XRCpuImage.Format
+    FORMAT_ARGB32: XRCpuImage.Format
+    FORMAT_RGBA32: XRCpuImage.Format
+    FORMAT_BGRA32: XRCpuImage.Format
+    FORMAT_RGB24: XRCpuImage.Format
+    FORMAT_H264RGB24: XRCpuImage.Format
     class Plane(_message.Message):
         __slots__ = ("row_stride", "pixel_stride", "data")
         ROW_STRIDE_FIELD_NUMBER: _ClassVar[int]

--- a/python/client/GrpcClient.py
+++ b/python/client/GrpcClient.py
@@ -1,0 +1,67 @@
+import grpc
+from typing import Awaitable, Iterable
+
+from cakelab.arflow_grpc.v1.ar_frame_pb2 import ARFrame 
+
+from cakelab.arflow_grpc.v1.arflow_service_pb2_grpc import ARFlowServiceStub
+from cakelab.arflow_grpc.v1.session_pb2 import SessionUuid, SessionMetadata
+from cakelab.arflow_grpc.v1.device_pb2 import Device
+
+from cakelab.arflow_grpc.v1.create_session_request_pb2 import CreateSessionRequest
+from cakelab.arflow_grpc.v1.create_session_response_pb2 import CreateSessionResponse
+from cakelab.arflow_grpc.v1.delete_session_request_pb2 import DeleteSessionRequest
+from cakelab.arflow_grpc.v1.delete_session_response_pb2 import DeleteSessionResponse
+from cakelab.arflow_grpc.v1.get_session_request_pb2 import GetSessionRequest
+from cakelab.arflow_grpc.v1.get_session_response_pb2 import GetSessionResponse
+from cakelab.arflow_grpc.v1.join_session_request_pb2 import JoinSessionRequest
+from cakelab.arflow_grpc.v1.join_session_response_pb2 import JoinSessionResponse
+from cakelab.arflow_grpc.v1.list_sessions_request_pb2 import ListSessionsRequest
+from cakelab.arflow_grpc.v1.list_sessions_response_pb2 import ListSessionsResponse
+from cakelab.arflow_grpc.v1.save_ar_frames_request_pb2 import SaveARFramesRequest
+from cakelab.arflow_grpc.v1.save_ar_frames_response_pb2 import SaveARFramesResponse
+
+class GrpcClient:
+    def __init__(self, url):
+        self.channel = grpc.insecure_channel(url)
+    async def CreateSessionAsync(self, name: str, device: Device, save_path: str = "") -> CreateSessionResponse:
+        request = CreateSessionRequest(
+            session_metadata=SessionMetadata(name=name, save_path=save_path),
+            device=device
+        )
+        response: Awaitable[CreateSessionResponse] = ARFlowServiceStub(self.channel).CreateSession(request)
+        return response
+    async def DeleteSessionAsync(self, session_id: str) -> DeleteSessionResponse:
+        request = DeleteSessionRequest(
+            session_id=SessionUuid(value = session_id)
+        )
+        response: Awaitable[DeleteSessionResponse] = ARFlowServiceStub(self.channel).DeleteSession(request)
+        return response
+    async def GetSessionAsync(self, session_id: str) -> GetSessionResponse:
+        request = GetSessionRequest(
+            session_id=SessionUuid(value=session_id)
+        )
+        response: Awaitable[GetSessionResponse] = ARFlowServiceStub(self.channel).GetSession(request)
+        return response
+    async def JoinSessionAsync(self, session_id: str, device: Device) -> JoinSessionResponse:
+        request = JoinSessionRequest(
+            session_id=SessionUuid(value=session_id),
+            device=device
+        )
+        response: Awaitable[JoinSessionResponse] = ARFlowServiceStub(self.channel).JoinSession(request)
+        return response
+    async def ListSessionsAsync(self) -> ListSessionsResponse:
+        request = ListSessionsRequest()
+        response: Awaitable[ListSessionsResponse] = ARFlowServiceStub(self.channel).ListSessions(request)
+        return response
+    async def SaveARFramesAsync(self, session_id: str, ar_frames: Iterable[ARFrame], device: Device) -> SaveARFramesResponse:
+        request = SaveARFramesRequest(
+            session_id=SessionUuid(value=session_id),
+            frames=ar_frames,
+            device=device
+        )
+        response: Awaitable[SaveARFramesResponse] = ARFlowServiceStub(self.channel).SaveARFrames(request)
+        return response
+
+    def close(self):
+        self.channel.close()
+    

--- a/python/client/GrpcClient.py
+++ b/python/client/GrpcClient.py
@@ -17,6 +17,8 @@ from cakelab.arflow_grpc.v1.join_session_request_pb2 import JoinSessionRequest
 from cakelab.arflow_grpc.v1.join_session_response_pb2 import JoinSessionResponse
 from cakelab.arflow_grpc.v1.list_sessions_request_pb2 import ListSessionsRequest
 from cakelab.arflow_grpc.v1.list_sessions_response_pb2 import ListSessionsResponse
+from cakelab.arflow_grpc.v1.leave_session_request_pb2 import LeaveSessionRequest
+from cakelab.arflow_grpc.v1.leave_session_response_pb2 import LeaveSessionResponse
 from cakelab.arflow_grpc.v1.save_ar_frames_request_pb2 import SaveARFramesRequest
 from cakelab.arflow_grpc.v1.save_ar_frames_response_pb2 import SaveARFramesResponse
 
@@ -52,6 +54,13 @@ class GrpcClient:
     async def list_sessions_async(self) -> ListSessionsResponse:
         request = ListSessionsRequest()
         response: Awaitable[ListSessionsResponse] = ARFlowServiceStub(self.channel).ListSessions(request)
+        return response
+    async def leave_session_async(self, session_id: str, device: Device) -> LeaveSessionResponse:
+        request = LeaveSessionRequest(
+            session_id=SessionUuid(value=session_id),
+            device=device
+        )
+        response: Awaitable[LeaveSessionResponse] = ARFlowServiceStub(self.channel).LeaveSession(request)
         return response
     async def save_ar_frames_async(self, session_id: str, ar_frames: Iterable[ARFrame], device: Device) -> SaveARFramesResponse:
         request = SaveARFramesRequest(

--- a/python/client/GrpcClient.py
+++ b/python/client/GrpcClient.py
@@ -23,37 +23,37 @@ from cakelab.arflow_grpc.v1.save_ar_frames_response_pb2 import SaveARFramesRespo
 class GrpcClient:
     def __init__(self, url):
         self.channel = grpc.insecure_channel(url)
-    async def CreateSessionAsync(self, name: str, device: Device, save_path: str = "") -> CreateSessionResponse:
+    async def create_session_async(self, name: str, device: Device, save_path: str = "") -> CreateSessionResponse:
         request = CreateSessionRequest(
             session_metadata=SessionMetadata(name=name, save_path=save_path),
             device=device
         )
         response: Awaitable[CreateSessionResponse] = ARFlowServiceStub(self.channel).CreateSession(request)
         return response
-    async def DeleteSessionAsync(self, session_id: str) -> DeleteSessionResponse:
+    async def delete_session_async(self, session_id: str) -> DeleteSessionResponse:
         request = DeleteSessionRequest(
             session_id=SessionUuid(value = session_id)
         )
         response: Awaitable[DeleteSessionResponse] = ARFlowServiceStub(self.channel).DeleteSession(request)
         return response
-    async def GetSessionAsync(self, session_id: str) -> GetSessionResponse:
+    async def get_session_async(self, session_id: str) -> GetSessionResponse:
         request = GetSessionRequest(
             session_id=SessionUuid(value=session_id)
         )
         response: Awaitable[GetSessionResponse] = ARFlowServiceStub(self.channel).GetSession(request)
         return response
-    async def JoinSessionAsync(self, session_id: str, device: Device) -> JoinSessionResponse:
+    async def join_session_async(self, session_id: str, device: Device) -> JoinSessionResponse:
         request = JoinSessionRequest(
             session_id=SessionUuid(value=session_id),
             device=device
         )
         response: Awaitable[JoinSessionResponse] = ARFlowServiceStub(self.channel).JoinSession(request)
         return response
-    async def ListSessionsAsync(self) -> ListSessionsResponse:
+    async def list_sessions_async(self) -> ListSessionsResponse:
         request = ListSessionsRequest()
         response: Awaitable[ListSessionsResponse] = ARFlowServiceStub(self.channel).ListSessions(request)
         return response
-    async def SaveARFramesAsync(self, session_id: str, ar_frames: Iterable[ARFrame], device: Device) -> SaveARFramesResponse:
+    async def save_ar_frames_async(self, session_id: str, ar_frames: Iterable[ARFrame], device: Device) -> SaveARFramesResponse:
         request = SaveARFramesRequest(
             session_id=SessionUuid(value=session_id),
             frames=ar_frames,

--- a/python/client/clients/cli.py
+++ b/python/client/clients/cli.py
@@ -21,8 +21,8 @@ class CLIClient:
     running: Thread | None = None
     stop_event: Event | None = None
     def __init__(self):
-        host = input("Enter hostname")
-        port = input("Enter port")
+        host = input("Enter hostname: ")
+        port = input("Enter port: ")
         self.client = GrpcClient(f"{host}:{port}")
         asyncio.run(self.__manage_sessions())
 

--- a/python/client/clients/cli.py
+++ b/python/client/clients/cli.py
@@ -83,7 +83,7 @@ class CLIClient:
 
     async def __join_session(self):
         if self.session is None: return
-        runner = SessionRunner(self.session, GetDeviceInfo.get_device_info(), self.__on_frame)
+        runner = SessionRunner(self.session, GetDeviceInfo.get_device_info(), self.__on_frame, 250)
         print("Currently only able to record camera frames")
         while True:
             print("Options:")
@@ -105,6 +105,7 @@ class CLIClient:
                         self.stop_event = Event()
                         self.running = Thread(target=self.__record_frame, args=(runner,))
                         self.running.start()
+                        await runner.start_recording()
                         print("Starting Recording")
                 case "2":
                     if self.running:

--- a/python/client/clients/cli.py
+++ b/python/client/clients/cli.py
@@ -1,42 +1,48 @@
-
+"""This module provides a CLI client for managing AR sessions using gRPC."""
+import asyncio
+import logging
+from threading import Event, Thread
+from time import sleep
 
 from GrpcClient import GrpcClient
 from util.GetDeviceInfo import GetDeviceInfo
 from util.SessionRunner import SessionRunner
 
-from cakelab.arflow_grpc.v1.device_pb2 import Device
-from cakelab.arflow_grpc.v1.session_pb2 import Session
 from cakelab.arflow_grpc.v1.ar_frame_pb2 import ARFrame
-
 from cakelab.arflow_grpc.v1.create_session_response_pb2 import CreateSessionResponse
+from cakelab.arflow_grpc.v1.device_pb2 import Device
 from cakelab.arflow_grpc.v1.list_sessions_response_pb2 import ListSessionsResponse
+from cakelab.arflow_grpc.v1.session_pb2 import Session
 
-import asyncio
-from threading import Thread
-from threading import Event
-from time import sleep
 
 class CLIClient:
     """A simple CLI client for managing AR sessions."""
+
     session: Session | None = None
     running: Thread | None = None
     stop_event: Event | None = None
+
     def __init__(self):
+        """Initialize the CLI with appropriate port and host."""
         host = input("Enter hostname: ")
         port = input("Enter port: ")
         self.client = GrpcClient(f"{host}:{port}")
         asyncio.run(self.__manage_sessions())
 
     async def __manage_sessions(self):
-        """
-        Manage AR sessions through a CLI interface.
+        """Manage AR sessions through a CLI interface.
+
         Very basic.
         """
         while True:
             print("Available Sessions:")
-            session_list: list[Session] = list((await self.client.list_sessions_async()).sessions)
+            session_list: list[Session] = list(
+                (await self.client.list_sessions_async()).sessions
+            )
             for session in session_list:
-                print(f"   Name: {session.metadata.name}, # of Devices: {len(session.devices)}")
+                print(
+                    f"   Name: {session.metadata.name}, # of Devices: {len(session.devices)}"
+                )
             print("Options:")
             print("1. Create and Join  Session")
             print("2. Join Session")
@@ -48,29 +54,51 @@ class CLIClient:
                 case "1":
                     name: str = input("Enter session name: ")
                     if any(session.metadata.name == name for session in session_list):
-                        name = input(f"Session with name '{name}' already exists. Please choose a different name:")
+                        name = input(
+                            f"Session with name '{name}' already exists. Please choose a different name:"
+                        )
                     device: Device = GetDeviceInfo.get_device_info()
                     try:
-                        self.session = (await self.client.create_session_async(name, device)).session
+                        self.session = (
+                            await self.client.create_session_async(name, device)
+                        ).session
                         print("Created Session")
                         await self.__join_session()
                     except Exception as e:
                         print(f"Failed to create session: {e}")
                 case "2":
                     name: str = input("Enter session name to join: ")
-                    target_session: Session | None = next((session for session in session_list if session.metadata.name == name), None)
+                    target_session: Session | None = next(
+                        (
+                            session
+                            for session in session_list
+                            if session.metadata.name == name
+                        ),
+                        None,
+                    )
                     if target_session is None:
                         print(f"No session found with name '{name}'")
                         continue
                     try:
-                        self.session = (await self.client.join_session_async(target_session.id.value, GetDeviceInfo.get_device_info())).session
+                        self.session = (
+                            await self.client.join_session_async(
+                                target_session.id.value, GetDeviceInfo.get_device_info()
+                            )
+                        ).session
                         print("Joined Session")
                         await self.__join_session()
                     except Exception as e:
                         print(f"Failed to join session: {e}")
                 case "3":
                     name: str = input("Enter session name to delete: ")
-                    target_session: Session | None = next((session for session in session_list if session.metadata.name == name), None)
+                    target_session: Session | None = next(
+                        (
+                            session
+                            for session in session_list
+                            if session.metadata.name == name
+                        ),
+                        None,
+                    )
                     if target_session is None:
                         print(f"No session found with name '{name}'")
                         continue
@@ -87,11 +115,12 @@ class CLIClient:
                     print("Invalid Option")
 
     async def __join_session(self):
-        """
-        Join an existing session and start recording frames.
-        """
-        if self.session is None: return
-        runner = SessionRunner(self.session, GetDeviceInfo.get_device_info(), self.__on_frame, 2000)
+        """Join an existing session and start recording frames."""
+        if self.session is None:
+            return
+        runner = SessionRunner(
+            self.session, GetDeviceInfo.get_device_info(), self.__on_frame, 2000
+        )
         print("Currently only able to record camera frames")
         while True:
             print("Options:")
@@ -113,11 +142,13 @@ class CLIClient:
                         self.running = None
                         self.stop_event = None
                     else:
-                        #start recording
+                        # start recording
                         print("Starting Recording")
                         self.stop_event = Event()
                         runner.start()
-                        self.running = Thread(target=self.__record_frame, args=(runner,))
+                        self.running = Thread(
+                            target=self.__record_frame, args=(runner,)
+                        )
                         self.running.start()
                         await runner.start_recording()
                 case "2":
@@ -129,7 +160,9 @@ class CLIClient:
                         self.running.join()
                         self.running = None
                         self.stop_event = None
-                    await self.client.leave_session_async(self.session.id.value, GetDeviceInfo.get_device_info())
+                    await self.client.leave_session_async(
+                        self.session.id.value, GetDeviceInfo.get_device_info()
+                    )
                     print("Leaving Session")
                     return
                 case _:
@@ -141,20 +174,21 @@ class CLIClient:
             asyncio.run(runner.gather_camera_frame_async())
             sleep(2)
 
-
-    async def __on_frame(self, session: Session, frame: ARFrame , device: Device):
+    async def __on_frame(self, session: Session, frame: ARFrame, device: Device):
         # handler for a callback when an AR frame is gathered and needs to be sent to the server
         if self.session is None:
             return
         await self.client.save_ar_frames_async(
             session_id=self.session.id.value,
             ar_frames=[frame],
-            device=GetDeviceInfo.get_device_info()
+            device=GetDeviceInfo.get_device_info(),
         )
 
+
 def main():
+    """Main function to run the CLI client."""
     CLIClient()
-    
-    
+
+
 if __name__ == "__main__":
     main()

--- a/python/client/clients/cli.py
+++ b/python/client/clients/cli.py
@@ -6,13 +6,20 @@ from util.SessionRunner import SessionRunner
 
 from cakelab.arflow_grpc.v1.device_pb2 import Device
 from cakelab.arflow_grpc.v1.session_pb2 import Session
+from cakelab.arflow_grpc.v1.ar_frame_pb2 import ARFrame
 
 from cakelab.arflow_grpc.v1.create_session_response_pb2 import CreateSessionResponse
 from cakelab.arflow_grpc.v1.list_sessions_response_pb2 import ListSessionsResponse
+
 import asyncio
+from threading import Thread
+from threading import Event
+from time import sleep
 
 class CLIClient:
     session: Session | None = None
+    running: Thread | None = None
+    stop_event: Event | None = None
     def __init__(self):
         host = input("Enter hostname")
         port = input("Enter port")
@@ -22,7 +29,7 @@ class CLIClient:
     async def __manage_sessions(self):
         while True:
             print("Available Sessions:")
-            session_list: list[Session] = list((await self.client.ListSessionsAsync()).sessions)
+            session_list: list[Session] = list((await self.client.list_sessions_async()).sessions)
             for session in session_list:
                 print(f"   Name: {session.metadata.name}, # of Devices: {len(session.devices)}")
             print("Options:")
@@ -39,9 +46,9 @@ class CLIClient:
                         name = input(f"Session with name '{name}' already exists. Please choose a different name:")
                     device: Device = GetDeviceInfo.get_device_info()
                     try:
-                        session = (await self.client.CreateSessionAsync(name, device)).session
+                        self.session = (await self.client.create_session_async(name, device)).session
                         print("Created Session")
-                        await self.__join_session(session)
+                        await self.__join_session()
                     except Exception as e:
                         print(f"Failed to create session: {e}")
                 case "2":
@@ -51,9 +58,9 @@ class CLIClient:
                         print(f"No session found with name '{name}'")
                         continue
                     try:
-                        session = await self.client.JoinSessionAsync(target_session.id.value, GetDeviceInfo.get_device_info())
+                        self.session = (await self.client.join_session_async(target_session.id.value, GetDeviceInfo.get_device_info())).session
                         print("Joined Session")
-                        await self.__join_session(session)
+                        await self.__join_session()
                     except Exception as e:
                         print(f"Failed to join session: {e}")
                 case "3":
@@ -63,7 +70,7 @@ class CLIClient:
                         print(f"No session found with name '{name}'")
                         continue
                     try:
-                        await self.client.DeleteSessionAsync(target_session.id.value)
+                        await self.client.delete_session_async(target_session.id.value)
                         print(f"Session '{name}' deleted successfully.")
                     except Exception as e:
                         print(f"Failed to delete session: {e}")
@@ -73,8 +80,54 @@ class CLIClient:
                     return
                 case _:
                     print("Invalid Option")
-    async def __join_session(self, session: Session):
-        print("Active session logic missing! Implement me!")
+
+    async def __join_session(self):
+        if self.session is None: return
+        runner = SessionRunner(self.session, GetDeviceInfo.get_device_info(), self.__on_frame)
+        print("Currently only able to record camera frames")
+        while True:
+            print("Options:")
+            if self.running:
+                print("1. Stop Recording")
+            else:
+                print("1. Start Recording")
+            print("2. Leave Session")
+            choice: str = input("Choose an option: ")
+            match choice:
+                case "1":
+                    if self.running:
+                        self.stop_event.set()
+                        self.running.join()
+                        self.running = None
+                        self.stop_event = None
+                        print("Stopping Recording")
+                    else:
+                        self.stop_event = Event()
+                        self.running = Thread(target=self.__record_frame, args=(runner,))
+                        self.running.start()
+                        print("Starting Recording")
+                case "2":
+                    await self.client.leave_session_async(self.session.id.value, GetDeviceInfo.get_device_info())
+                    print("Leaving Session")
+                    return
+                case _:
+                    print("Invalid Option")
+
+    def __record_frame(self, runner: SessionRunner):
+        while not self.stop_event.is_set():
+            asyncio.run(runner.gather_camera_frame_async())
+            sleep(0.25)
+
+
+    async def __on_frame(self, session: Session, frame: ARFrame , device: Device):
+        if self.session is None:
+            return
+        await self.client.save_ar_frames_async(
+            session_id=self.session.id.value,
+            ar_frames=[frame],
+            device=GetDeviceInfo.get_device_info()
+        )
+
 def main():
     CLIClient()
     

--- a/python/client/clients/cli.py
+++ b/python/client/clients/cli.py
@@ -107,6 +107,11 @@ class CLIClient:
                         self.running.start()
                         print("Starting Recording")
                 case "2":
+                    if self.running:
+                        self.stop_event.set()
+                        self.running.join()
+                        self.running = None
+                        self.stop_event = None
                     await self.client.leave_session_async(self.session.id.value, GetDeviceInfo.get_device_info())
                     print("Leaving Session")
                     return

--- a/python/client/clients/cli.py
+++ b/python/client/clients/cli.py
@@ -1,0 +1,83 @@
+
+
+from GrpcClient import GrpcClient
+from util.GetDeviceInfo import GetDeviceInfo
+from util.SessionRunner import SessionRunner
+
+from cakelab.arflow_grpc.v1.device_pb2 import Device
+from cakelab.arflow_grpc.v1.session_pb2 import Session
+
+from cakelab.arflow_grpc.v1.create_session_response_pb2 import CreateSessionResponse
+from cakelab.arflow_grpc.v1.list_sessions_response_pb2 import ListSessionsResponse
+import asyncio
+
+class CLIClient:
+    session: Session | None = None
+    def __init__(self):
+        host = input("Enter hostname")
+        port = input("Enter port")
+        self.client = GrpcClient(f"{host}:{port}")
+        asyncio.run(self.__manage_sessions())
+
+    async def __manage_sessions(self):
+        while True:
+            print("Available Sessions:")
+            session_list: list[Session] = list((await self.client.ListSessionsAsync()).sessions)
+            for session in session_list:
+                print(f"   Name: {session.metadata.name}, # of Devices: {len(session.devices)}")
+            print("Options:")
+            print("1. Create and Join  Session")
+            print("2. Join Session")
+            print("3. Delete Session")
+            print("4. Refresh")
+            print("5. Exit")
+            choice: str = input("Choose an option: ")
+            match choice:
+                case "1":
+                    name: str = input("Enter session name: ")
+                    if any(session.metadata.name == name for session in session_list):
+                        name = input(f"Session with name '{name}' already exists. Please choose a different name:")
+                    device: Device = GetDeviceInfo.get_device_info()
+                    try:
+                        session = (await self.client.CreateSessionAsync(name, device)).session
+                        print("Created Session")
+                        await self.__join_session(session)
+                    except Exception as e:
+                        print(f"Failed to create session: {e}")
+                case "2":
+                    name: str = input("Enter session name to join: ")
+                    target_session: Session | None = next((session for session in session_list if session.metadata.name == name), None)
+                    if target_session is None:
+                        print(f"No session found with name '{name}'")
+                        continue
+                    try:
+                        session = await self.client.JoinSessionAsync(target_session.id.value, GetDeviceInfo.get_device_info())
+                        print("Joined Session")
+                        await self.__join_session(session)
+                    except Exception as e:
+                        print(f"Failed to join session: {e}")
+                case "3":
+                    name: str = input("Enter session name to delete: ")
+                    target_session: Session | None = next((session for session in session_list if session.metadata.name == name), None)
+                    if target_session is None:
+                        print(f"No session found with name '{name}'")
+                        continue
+                    try:
+                        await self.client.DeleteSessionAsync(target_session.id.value)
+                        print(f"Session '{name}' deleted successfully.")
+                    except Exception as e:
+                        print(f"Failed to delete session: {e}")
+                case "4":
+                    continue
+                case "5":
+                    return
+                case _:
+                    print("Invalid Option")
+    async def __join_session(self, session: Session):
+        print("Active session logic missing! Implement me!")
+def main():
+    CLIClient()
+    
+    
+if __name__ == "__main__":
+    main()

--- a/python/client/h264_tests/compression_test_20250629_160028.csv
+++ b/python/client/h264_tests/compression_test_20250629_160028.csv
@@ -1,0 +1,5 @@
+Configuration,Resolution,Compression,Bytes Sent,Frames,FPS Achieved,PSNR (dB),Bandwidth (Mbps),Compression Ratio
+SD_Uncompressed,640x480,Uncompressed,138240000,150,27.35,N/A,221.18,N/A
+SD_Compressed,640x480,H.264,11520000,150,27.50,54.93,18.43,0.2:1
+HD_Uncompressed,1920x1080,Uncompressed,933120000,150,26.97,N/A,1492.99,N/A
+HD_Compressed,1920x1080,H.264,77760000,150,27.67,58.28,124.42,0.3:1

--- a/python/client/h264_tests/compression_test_20250629_160028.json
+++ b/python/client/h264_tests/compression_test_20250629_160028.json
@@ -1,0 +1,69 @@
+{
+  "timestamp": "20250629_160028",
+  "results": [
+    {
+      "config": {
+        "name": "SD_Uncompressed",
+        "width": 640,
+        "height": 480,
+        "compressed": false
+      },
+      "measurements": {
+        "bytes_sent": 138240000,
+        "frames_processed": 150,
+        "fps_achieved": 27.35127730286215,
+        "psnr_score": null,
+        "bandwidth_mbps": 221.184,
+        "compression_ratio": null
+      }
+    },
+    {
+      "config": {
+        "name": "SD_Compressed",
+        "width": 640,
+        "height": 480,
+        "compressed": true
+      },
+      "measurements": {
+        "bytes_sent": 11520000,
+        "frames_processed": 150,
+        "fps_achieved": 27.49798815353655,
+        "psnr_score": 54.927148,
+        "bandwidth_mbps": 18.432,
+        "compression_ratio": 0.21473934402652356
+      }
+    },
+    {
+      "config": {
+        "name": "HD_Uncompressed",
+        "width": 1920,
+        "height": 1080,
+        "compressed": false
+      },
+      "measurements": {
+        "bytes_sent": 933120000,
+        "frames_processed": 150,
+        "fps_achieved": 26.97079982709531,
+        "psnr_score": null,
+        "bandwidth_mbps": 1492.992,
+        "compression_ratio": null
+      }
+    },
+    {
+      "config": {
+        "name": "HD_Compressed",
+        "width": 1920,
+        "height": 1080,
+        "compressed": true
+      },
+      "measurements": {
+        "bytes_sent": 77760000,
+        "frames_processed": 150,
+        "fps_achieved": 27.665508148397013,
+        "psnr_score": 58.282008,
+        "bandwidth_mbps": 124.416,
+        "compression_ratio": 0.29552274457698224
+      }
+    }
+  ]
+}

--- a/python/client/h264_tests/compression_test_20250629_160414.csv
+++ b/python/client/h264_tests/compression_test_20250629_160414.csv
@@ -1,0 +1,5 @@
+Configuration,Resolution,Compression,Bytes Sent,Frames,FPS Achieved,PSNR (dB),Bandwidth (Mbps),Compression Ratio
+SD_Uncompressed,640x480,Uncompressed,138240000,150,26.99,N/A,221.18,N/A
+SD_Compressed,640x480,H.264,11520000,150,27.75,54.93,18.43,0.2:1
+HD_Uncompressed,1920x1080,Uncompressed,933120000,150,26.91,N/A,1492.99,N/A
+HD_Compressed,1920x1080,H.264,77760000,150,27.43,58.28,124.42,0.3:1

--- a/python/client/h264_tests/compression_test_20250629_160414.json
+++ b/python/client/h264_tests/compression_test_20250629_160414.json
@@ -1,0 +1,69 @@
+{
+  "timestamp": "20250629_160414",
+  "results": [
+    {
+      "config": {
+        "name": "SD_Uncompressed",
+        "width": 640,
+        "height": 480,
+        "compressed": false
+      },
+      "measurements": {
+        "bytes_sent": 138240000,
+        "frames_processed": 150,
+        "fps_achieved": 26.986975899549517,
+        "psnr_score": null,
+        "bandwidth_mbps": 221.184,
+        "compression_ratio": null
+      }
+    },
+    {
+      "config": {
+        "name": "SD_Compressed",
+        "width": 640,
+        "height": 480,
+        "compressed": true
+      },
+      "measurements": {
+        "bytes_sent": 11520000,
+        "frames_processed": 150,
+        "fps_achieved": 27.74539831476932,
+        "psnr_score": 54.927148,
+        "bandwidth_mbps": 18.432,
+        "compression_ratio": 0.21473934402652356
+      }
+    },
+    {
+      "config": {
+        "name": "HD_Uncompressed",
+        "width": 1920,
+        "height": 1080,
+        "compressed": false
+      },
+      "measurements": {
+        "bytes_sent": 933120000,
+        "frames_processed": 150,
+        "fps_achieved": 26.912212488929978,
+        "psnr_score": null,
+        "bandwidth_mbps": 1492.992,
+        "compression_ratio": null
+      }
+    },
+    {
+      "config": {
+        "name": "HD_Compressed",
+        "width": 1920,
+        "height": 1080,
+        "compressed": true
+      },
+      "measurements": {
+        "bytes_sent": 77760000,
+        "frames_processed": 150,
+        "fps_achieved": 27.425192436060282,
+        "psnr_score": 58.282008,
+        "bandwidth_mbps": 124.416,
+        "compression_ratio": 0.29552274457698224
+      }
+    }
+  ]
+}

--- a/python/client/util/GetDeviceInfo.py
+++ b/python/client/util/GetDeviceInfo.py
@@ -1,16 +1,28 @@
-from cakelab.arflow_grpc.v1.device_pb2 import Device
+"""Pretty much a clone of the Unity GetDeviceInfo class, but in Python. (except for uid/type).
+
+This class is used to get the device information such as name, model, type, and uid.
+"""
 import platform
 import uuid
 
+from cakelab.arflow_grpc.v1.device_pb2 import Device
+
+
 class GetDeviceInfo:
+    """Pretty much a clone of the Unity GetDeviceInfo class, but in Python. (except for uid/type).
+
+    This class is used to get the device information such as name, model, type, and uid.
+    """
+
     @staticmethod
     def get_device_info() -> Device:
+        """Get the device information."""
         name = platform.node()
-        #not sure what model is, im just gonna leave it as system name combined with version, change this later
+        # not sure what model is, im just gonna leave it as system name combined with version, change this later
         model = platform.system() + platform.version()
         return Device(
             name=name,
             model=model,
-            type=3, #for now only functions on desktops
-            uid= str(uuid.uuid3(uuid.NAMESPACE_DNS, name + model))
+            type=3,  # for now only functions on desktops
+            uid=str(uuid.uuid3(uuid.NAMESPACE_DNS, name + model)),
         )

--- a/python/client/util/GetDeviceInfo.py
+++ b/python/client/util/GetDeviceInfo.py
@@ -1,0 +1,16 @@
+from cakelab.arflow_grpc.v1.device_pb2 import Device
+import platform
+import uuid
+
+class GetDeviceInfo:
+    @staticmethod
+    def get_device_info() -> Device:
+        name = platform.node()
+        #not sure what model is, im just gonna leave it as system name combined with version, change this later
+        model = platform.system() + platform.version()
+        return Device(
+            name=name,
+            model=model,
+            type=3, #for now only functions on desktops
+            uid= str(uuid.uuid3(uuid.NAMESPACE_DNS, name + model))
+        )

--- a/python/client/util/SessionRunner.py
+++ b/python/client/util/SessionRunner.py
@@ -1,0 +1,65 @@
+from cakelab.arflow_grpc.v1.session_pb2 import Session
+from cakelab.arflow_grpc.v1.device_pb2 import Device
+
+from cakelab.arflow_grpc.v1.ar_frame_pb2 import ARFrame
+from cakelab.arflow_grpc.v1.color_frame_pb2 import ColorFrame
+from cakelab.arflow_grpc.v1.xr_cpu_image_pb2 import XRCpuImage
+from cakelab.arflow_grpc.v1.vector2_int_pb2 import Vector2Int
+from google.protobuf.timestamp_pb2 import Timestamp
+import cv2
+import time
+from typing import Callable, Coroutine, Any
+
+class SessionRunner:
+    camera : cv2.VideoCapture | None = None
+    session: Session | None = None
+    device: Device | None = None
+    onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]] | None = None
+    def __init__(self, session: Session, device: Device, onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]]):
+        self.camera = cv2.VideoCapture(0)
+        self.onARFrame = onARFrame
+        self.session = session
+        self.device = device
+    def __del__(self):
+        if self.camera is not None:
+            self.camera.release()
+            self.camera = None
+    async def gather_camera_frame_async(self) -> None:
+        if self.camera is None:
+            return
+        ret, frame = self.camera.read()
+        if not ret:
+            return
+        height, width = frame.shape[:2]
+        yuv = (cv2.cvtColor(frame, cv2.COLOR_BGR2YUV_I420)).flatten()
+        y_size = width * height
+        uv_size = y_size // 4
+        Y: XRCpuImage.Plane = XRCpuImage.Plane(data = (yuv[:y_size].reshape((height, width))).tobytes(), row_stride = width, pixel_stride=1)
+        U: XRCpuImage.Plane = XRCpuImage.Plane(data = (yuv[y_size:y_size + uv_size].reshape((height // 2, width // 2))).tobytes(), row_stride = width // 2, pixel_stride=1)
+        V: XRCpuImage.Plane = XRCpuImage.Plane(data = (yuv[y_size + uv_size:].reshape((height // 2, width // 2))).tobytes(), row_stride = width // 2, pixel_stride=1)
+        # Trim the U and V planes because ARFlow adds an extra byte as it is a bug with the android format
+        U.data = U.data[:-1]
+        V.data = V.data[:-1]
+        now = time.time()
+        timestamp = Timestamp()
+        nanos = int(now * 1e9)
+        Timestamp.FromNanoseconds(timestamp, nanos)
+        xrcpu_image: XRCpuImage = XRCpuImage(
+            dimensions= Vector2Int(x=width, y=height),
+            format= XRCpuImage.FORMAT_ANDROID_YUV_420_888,
+            timestamp=now,
+            planes=[Y, U, V]
+        )
+        color_frame = ColorFrame(
+            image=xrcpu_image,
+            device_timestamp=timestamp
+        )
+        ar_frame = ARFrame(
+            color_frame=color_frame
+        )
+        if self.onARFrame and self.session and self.device:
+            await self.onARFrame(self.session, ar_frame, self.device)
+        
+
+
+

--- a/python/client/util/SessionRunner.py
+++ b/python/client/util/SessionRunner.py
@@ -1,28 +1,44 @@
+"""This module provides a SessionRunner class that manages AR sessions and gathers AR frames."""
+import subprocess
+import threading
+import time
 from asyncio import gather
-from cakelab.arflow_grpc.v1.session_pb2 import Session
-from cakelab.arflow_grpc.v1.device_pb2 import Device
+from typing import Any, Callable, Coroutine
+
+import cv2
+import ffmpeg
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from cakelab.arflow_grpc.v1.ar_frame_pb2 import ARFrame
 from cakelab.arflow_grpc.v1.color_frame_pb2 import ColorFrame
-from cakelab.arflow_grpc.v1.xr_cpu_image_pb2 import XRCpuImage
+from cakelab.arflow_grpc.v1.device_pb2 import Device
+from cakelab.arflow_grpc.v1.session_pb2 import Session
 from cakelab.arflow_grpc.v1.vector2_int_pb2 import Vector2Int
-from google.protobuf.timestamp_pb2 import Timestamp
-import ffmpeg
-import subprocess
-import threading
-import cv2
-import time
-from typing import Callable, Coroutine, Any
+from cakelab.arflow_grpc.v1.xr_cpu_image_pb2 import XRCpuImage
+
 
 class SessionRunner:
-    camera : cv2.VideoCapture | None = None
+    """A class which represents a sessions available functionality into simply calling the onArFrame callback every time an ARFrame is gathered.
+
+    For example, gathering gyroscope, color, depth, and other frames.
+    For now, only supports gathering frames in H264 format.
+    """
+
+    camera: cv2.VideoCapture | None = None
     session: Session | None = None
     device: Device | None = None
-    onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]] | None = None
-    def __init__(self, session: Session, device: Device, onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]], gathering_interval: int):
-        """
-        Initializes the SessionRunner with a session, device, and callback for AR frames.
-        """
+    onARFrame: (
+        Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]] | None
+    ) = None
+
+    def __init__(
+        self,
+        session: Session,
+        device: Device,
+        onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]],
+        gathering_interval: int,
+    ):
+        """Initializes the SessionRunner with a session, device, and callback for AR frames."""
         self.onARFrame = onARFrame
         self.session = session
         self.device = device
@@ -30,26 +46,28 @@ class SessionRunner:
         self.gatherer_thread = None
         self.reader_thread = None
         self.gathering_interval = gathering_interval
-        self.width = None 
+        self.width = None
         self.height = None
         self.chunk_buffer = bytearray()
         self.num_frames_stored = 0
         self.ffmpeg_enc = None
         self.thread_mutex: threading.Lock = threading.Lock()
         self.buffer_mutex: threading.Lock = threading.Lock()
+
     def frame_encoder(self):
-        """ Continuously captures frames from the camera, and writes to ffmpegs pipe to encode them"""
+        """Continuously captures frames from the camera, and writes to ffmpegs pipe to encode them."""
         while not self.stopped:
             ret, frame = self.camera.read()
             if not ret:
-                break 
+                break
             frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             self.ffmpeg_enc.stdin.write(frame_rgb.tobytes())
             self.thread_mutex.acquire()
             self.num_frames_stored += 1
             self.thread_mutex.release()
-    def encoding_reciever(self):
-        """ Continuously reads encoded data from ffmpeg and stores it in a buffer"""
+
+    def encoding_receiver(self):
+        """Continuously reads encoded data from ffmpeg and stores it in a buffer."""
         while not self.stopped:
             data = self.ffmpeg_enc.stdout.read(4096)
             if not data:
@@ -57,37 +75,47 @@ class SessionRunner:
             self.buffer_mutex.acquire()
             self.chunk_buffer.extend(data)
             self.buffer_mutex.release()
+
     def start(self):
-        """
-        Starts this session runner, initializing camera and ffmpeg encoder.
-        """
+        """Starts this session runner, initializing camera and ffmpeg encoder."""
         self.stopped = False
         if self.camera is None:
             self.camera = cv2.VideoCapture(0)
             self.width = int(self.camera.get(cv2.CAP_PROP_FRAME_WIDTH))
             self.height = int(self.camera.get(cv2.CAP_PROP_FRAME_HEIGHT))
-        self.ffmpeg_enc = self.ffmpeg_enc = subprocess.Popen([
-            'ffmpeg',
-            '-f', 'rawvideo',
-            '-pix_fmt', 'bgr24',
-            '-s', f'{self.width}x{self.height}',
-            '-i', 'pipe:0',
-            '-c:v', 'libx264',
-            '-preset', 'ultrafast',
-            '-tune', 'zerolatency',
-            '-f', 'h264',
-            'pipe:1'
-        ], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        self.ffmpeg_enc = self.ffmpeg_enc = subprocess.Popen(
+            [
+                "ffmpeg",
+                "-f",
+                "rawvideo",
+                "-pix_fmt",
+                "bgr24",
+                "-s",
+                f"{self.width}x{self.height}",
+                "-i",
+                "pipe:0",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "ultrafast",
+                "-tune",
+                "zerolatency",
+                "-f",
+                "h264",
+                "pipe:1",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+
     def stop(self):
-        """ 
-        Stops this session runner, releasing camera and ffmpeg resources.
-        """
+        """Stops this session runner, releasing camera and ffmpeg resources."""
         self.stopped = True
         if self.camera is not None:
             self.camera.release()
             self.camera = None
         if self.ffmpeg_enc is not None:
-            self.ffmpeg_enc.stdin.close() 
+            self.ffmpeg_enc.stdin.close()
             self.ffmpeg_enc.stdout.close()
             self.ffmpeg_enc.wait()
             self.ffmpeg_enc = None
@@ -97,44 +125,23 @@ class SessionRunner:
         if self.reader_thread is not None:
             self.reader_thread.join()
             self.reader_thread = None
+
     async def start_recording(self):
-        self.gatherer_thread = threading.Thread(target=self.frame_encoder, args=(), daemon=True )
+        """Starts the recording process by initializing a threads for frame gathering and encoding."""
+        self.gatherer_thread = threading.Thread(
+            target=self.frame_encoder, args=(), daemon=True
+        )
         self.gatherer_thread.start()
-        self.reader_thread = threading.Thread(target=self.encoding_reciever, args=(), daemon=True)
+        self.reader_thread = threading.Thread(
+            target=self.encoding_receiver, args=(), daemon=True
+        )
         self.reader_thread.start()
+
     async def gather_camera_frame_async(self) -> None:
-        """
-        Gathers a camera frame, encodes it, and sends it as an ARFrame.
+        """Gathers the needed data for camera frame(s), encodes it(them), and sends it(them) as an ARFrame.
+
         Current implementation gathers and sends frames in H264 format.
-        However you will find code to send individual RGB and YUV frames as well in the comment below.
-        """
-        """
-        #This code addresses implementation for gather frames in RGB and YUV formats without compression
-        #Mostly as a demonstration of how to do so in python
-        #Non - streaming required
-        if self.camera is None:
-            return
-        ret, frame = self.camera.read()
-        if not ret:
-            return
-        height, width = frame.shape[:2]
-        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-
-        #YUV Implementation
-
-        yuv = (cv2.cvtColor(frame, cv2.COLOR_BGR2YUV_I420)).flatten()
-        y_size = width * height
-        uv_size = y_size // 4
-        Y: XRCpuImage.Plane = XRCpuImage.Plane(data = (yuv[:y_size].reshape((height, width))).tobytes(), row_stride = width, pixel_stride=1)
-        U: XRCpuImage.Plane = XRCpuImage.Plane(data = (yuv[y_size:y_size + uv_size].reshape((height // 2, width // 2))).tobytes(), row_stride = width // 2, pixel_stride=1)
-        V: XRCpuImage.Plane = XRCpuImage.Plane(data = (yuv[y_size + uv_size:].reshape((height // 2, width // 2))).tobytes(), row_stride = width // 2, pixel_stride=1)
-        # Trim the U and V planes because ARFlow adds an extra byte as it is a bug with the android format
-        U.data = U.data[:-1]
-        V.data = V.data[:-1]
-
-        # rgb specific code
-
-        RGB = XRCpuImage.Plane(data=frame_rgb.tobytes())
+        Look in main branch for support for other formats.
         """
         h264 = None
         if not self.chunk_buffer:
@@ -143,8 +150,8 @@ class SessionRunner:
         self.buffer_mutex.acquire()
         h264 = XRCpuImage.Plane(
             data=bytes(self.chunk_buffer),
-            row_stride = self.num_frames_stored, #for now utilize the row stride field to store number of frames
-            pixel_stride = self.gathering_interval
+            row_stride=self.num_frames_stored,  # for now utilize the row stride field to store number of frames
+            pixel_stride=self.gathering_interval,
         )
         self.num_frames_stored = 0
         self.chunk_buffer.clear()
@@ -155,23 +162,15 @@ class SessionRunner:
         nanos = int(now * 1e9)
         Timestamp.FromNanoseconds(timestamp, nanos)
         xrcpu_image: XRCpuImage = XRCpuImage(
-            dimensions= Vector2Int(x=self.width, y=self.height),
-            #format= XRCpuImage.FORMAT_ANDROID_YUV_420_888,
+            dimensions=Vector2Int(x=self.width, y=self.height),
             timestamp=now,
-            format=16, # make a new format for streaming data
+            format=XRCpuImage.FORMAT_H264RGB24,
             planes=[h264],
         )
         color_frame = ColorFrame(
             image=xrcpu_image,
             device_timestamp=timestamp,
-
         )
-        ar_frame = ARFrame(
-            color_frame=color_frame
-        )
+        ar_frame = ARFrame(color_frame=color_frame)
         if self.onARFrame and self.session and self.device:
             await self.onARFrame(self.session, ar_frame, self.device)
-        
-
-
-

--- a/python/client/util/SessionRunner.py
+++ b/python/client/util/SessionRunner.py
@@ -1,3 +1,4 @@
+from asyncio import gather
 from cakelab.arflow_grpc.v1.session_pb2 import Session
 from cakelab.arflow_grpc.v1.device_pb2 import Device
 
@@ -6,6 +7,9 @@ from cakelab.arflow_grpc.v1.color_frame_pb2 import ColorFrame
 from cakelab.arflow_grpc.v1.xr_cpu_image_pb2 import XRCpuImage
 from cakelab.arflow_grpc.v1.vector2_int_pb2 import Vector2Int
 from google.protobuf.timestamp_pb2 import Timestamp
+import ffmpeg
+import subprocess
+import threading
 import cv2
 import time
 from typing import Callable, Coroutine, Any
@@ -15,22 +19,67 @@ class SessionRunner:
     session: Session | None = None
     device: Device | None = None
     onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]] | None = None
-    def __init__(self, session: Session, device: Device, onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]]):
+    def __init__(self, session: Session, device: Device, onARFrame: Callable[[Session, ARFrame, Device], Coroutine[Any, Any, None]], gathering_interval: int):
         self.camera = cv2.VideoCapture(0)
         self.onARFrame = onARFrame
         self.session = session
         self.device = device
+        self.stopped = False
+        self.gathering_interval = gathering_interval
+        self.width = int(self.camera.get(cv2.CAP_PROP_FRAME_WIDTH))
+        self.height = int(self.camera.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        self.chunk_buffer = bytearray()
+        self.num_frames_stored = 0
+        self.ffmpeg_enc = subprocess.Popen([
+            'ffmpeg',
+            '-f', 'rawvideo',
+            '-pix_fmt', 'bgr24',
+            '-s', f'{self.width}x{self.height}',
+            '-i', 'pipe:0',
+            '-c:v', 'libx264',
+            '-preset', 'ultrafast',
+            '-tune', 'zerolatency',
+            '-f', 'h264',
+            'pipe:1'
+        ], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        self.thread_mutex: threading.Lock = threading.Lock()
+    def frame_encoder(self):
+        while not self.stopped:
+            ret, frame = self.camera.read()
+            frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            if not ret:
+                break 
+            self.ffmpeg_enc.stdin.write(frame_rgb.tobytes())
+    def encoding_reciever(self):
+        while not self.stopped:
+            data = self.ffmpeg_enc.stdout.read(4096)
+            if not data:
+                break
+            self.thread_mutex.acquire()
+            self.num_frames_stored += 1
+            self.chunk_buffer.extend(data)
+            self.thread_mutex.release()
     def __del__(self):
         if self.camera is not None:
             self.camera.release()
             self.camera = None
+    async def start_recording(self):
+        threading.Thread(target=self.frame_encoder, args=(), daemon=True ).start()
+        threading.Thread(target=self.encoding_reciever, args=(), daemon=True).start()
+        print("hi")
     async def gather_camera_frame_async(self) -> None:
+        """
+        #Non - streaming required
         if self.camera is None:
             return
         ret, frame = self.camera.read()
         if not ret:
             return
         height, width = frame.shape[:2]
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+        #YUV Implementation
+
         yuv = (cv2.cvtColor(frame, cv2.COLOR_BGR2YUV_I420)).flatten()
         y_size = width * height
         uv_size = y_size // 4
@@ -40,19 +89,38 @@ class SessionRunner:
         # Trim the U and V planes because ARFlow adds an extra byte as it is a bug with the android format
         U.data = U.data[:-1]
         V.data = V.data[:-1]
+
+        # rgb specific code
+
+        RGB = XRCpuImage.Plane(data=frame_rgb.tobytes())
+        """
+        h264 = None
+        if not self.chunk_buffer:
+            return
+        self.thread_mutex.acquire()
+        h264 = XRCpuImage.Plane(
+            data=bytes(self.chunk_buffer),
+            row_stride = self.num_frames_stored, #for now utilize the row stride field to store number of frames
+            pixel_stride = self.gathering_interval
+        )
+        self.num_frames_stored = 0
+        self.chunk_buffer.clear()
+        self.thread_mutex.release()
         now = time.time()
         timestamp = Timestamp()
         nanos = int(now * 1e9)
         Timestamp.FromNanoseconds(timestamp, nanos)
         xrcpu_image: XRCpuImage = XRCpuImage(
-            dimensions= Vector2Int(x=width, y=height),
-            format= XRCpuImage.FORMAT_ANDROID_YUV_420_888,
+            dimensions= Vector2Int(x=self.width, y=self.height),
+            #format= XRCpuImage.FORMAT_ANDROID_YUV_420_888,
             timestamp=now,
-            planes=[Y, U, V]
+            format=16, # make a new format for streaming data
+            planes=[h264],
         )
         color_frame = ColorFrame(
             image=xrcpu_image,
-            device_timestamp=timestamp
+            device_timestamp=timestamp,
+
         )
         ar_frame = ARFrame(
             color_frame=color_frame

--- a/python/examples/simple/simple.py
+++ b/python/examples/simple/simple.py
@@ -5,19 +5,28 @@ from pathlib import Path
 
 import arflow
 
-
 class CustomService(arflow.ARFlowServicer):
-    def on_register(self, request: arflow.RegisterClientRequest):
-        """Called when a client registers."""
-        print("Client registered!")
-
-    def on_frame_received(self, decoded_data_frame: arflow.DecodedDataFrame):
-        """Called when a frame is received."""
-        print("Frame received!")
-
+    def on_save_ar_frames(self, frames, session_stream, device):
+        print("AR frame received")
+    def on_save_transform_frames(self, frames, session_stream, device):
+        print("Transform frame received")
+    def on_save_color_frames(self, frames, session_stream, device):
+        print("Color frame received")
+    def on_save_depth_frames(self, frames, session_stream, device):
+        print("Depth frame received")
+    def on_save_gyroscope_frames(self, frames, session_stream, device):
+        print("Gyroscope frame received")
+    def on_save_audio_frames(self, frames, session_stream, device):
+        print("Audio frame received")
+    def on_save_plane_detection_frames(self, frames, session_stream, device):
+        print("Plane detection frame received")
+    def on_save_point_cloud_frames(self, frames, session_stream, device):
+        print("Point cloud frame received")
+    def on_save_mesh_detection_frames(self, frames, session_stream, device):
+        print("Mesh detection frame received")
 
 def main():
-    arflow.run_server(CustomService, port=8500, save_dir=Path("./"))
+    arflow.run_server(CustomService, spawn_viewer = True, port=8500)
 
 
 if __name__ == "__main__":

--- a/unity/Packages/edu.wpi.cake.arflow/Runtime/Grpc/V1/XrCpuImage.cs
+++ b/unity/Packages/edu.wpi.cake.arflow/Runtime/Grpc/V1/XrCpuImage.cs
@@ -26,7 +26,7 @@ namespace CakeLab.ARFlow.Grpc.V1 {
           string.Concat(
             "CiljYWtlbGFiL2FyZmxvd19ncnBjL3YxL3hyX2NwdV9pbWFnZS5wcm90bxIW",
             "Y2FrZWxhYi5hcmZsb3dfZ3JwYy52MRooY2FrZWxhYi9hcmZsb3dfZ3JwYy92",
-            "MS92ZWN0b3IyX2ludC5wcm90byL4AwoKWFJDcHVJbWFnZRJCCgpkaW1lbnNp",
+            "MS92ZWN0b3IyX2ludC5wcm90byKOBQoKWFJDcHVJbWFnZRJCCgpkaW1lbnNp",
             "b25zGAEgASgLMiIuY2FrZWxhYi5hcmZsb3dfZ3JwYy52MS5WZWN0b3IySW50",
             "UgpkaW1lbnNpb25zEkEKBmZvcm1hdBgCIAEoDjIpLmNha2VsYWIuYXJmbG93",
             "X2dycGMudjEuWFJDcHVJbWFnZS5Gb3JtYXRSBmZvcm1hdBIcCgl0aW1lc3Rh",
@@ -34,14 +34,17 @@ namespace CakeLab.ARFlow.Grpc.V1 {
             "LmFyZmxvd19ncnBjLnYxLlhSQ3B1SW1hZ2UuUGxhbmVSBnBsYW5lcxpdCgVQ",
             "bGFuZRIdCgpyb3dfc3RyaWRlGAEgASgFUglyb3dTdHJpZGUSIQoMcGl4ZWxf",
             "c3RyaWRlGAIgASgFUgtwaXhlbFN0cmlkZRISCgRkYXRhGAMgASgMUgRkYXRh",
-            "IqMBCgZGb3JtYXQSFgoSRk9STUFUX1VOU1BFQ0lGSUVEEAASHgoaRk9STUFU",
+            "IrkCCgZGb3JtYXQSFgoSRk9STUFUX1VOU1BFQ0lGSUVEEAASHgoaRk9STUFU",
             "X0FORFJPSURfWVVWXzQyMF84ODgQARIwCixGT1JNQVRfSU9TX1lQX0NCQ1Jf",
-            "NDIwXzhCSV9QTEFOQVJfRlVMTF9SQU5HRRACEhcKE0ZPUk1BVF9ERVBUSEZM",
-            "T0FUMzIQBBIWChJGT1JNQVRfREVQVEhVSU5UMTYQBUKkAQoaY29tLmNha2Vs",
-            "YWIuYXJmbG93X2dycGMudjFCD1hyQ3B1SW1hZ2VQcm90b1ABogIDQ0FYqgIW",
-            "Q2FrZUxhYi5BUkZsb3cuR3JwYy5WMcoCFUNha2VsYWJcQXJmbG93R3JwY1xW",
-            "MeICIUNha2VsYWJcQXJmbG93R3JwY1xWMVxHUEJNZXRhZGF0YeoCF0Nha2Vs",
-            "YWI6OkFyZmxvd0dycGM6OlYxYgZwcm90bzM="));
+            "NDIwXzhCSV9QTEFOQVJfRlVMTF9SQU5HRRACEhgKFEZPUk1BVF9PTkVDT01Q",
+            "T05FTlQ4EAMSFwoTRk9STUFUX0RFUFRIRkxPQVQzMhAEEhYKEkZPUk1BVF9E",
+            "RVBUSFVJTlQxNhAFEhkKFUZPUk1BVF9PTkVDT01QT05FTlQzMhAGEhEKDUZP",
+            "Uk1BVF9BUkdCMzIQBxIRCg1GT1JNQVRfUkdCQTMyEAgSEQoNRk9STUFUX0JH",
+            "UkEzMhAJEhAKDEZPUk1BVF9SR0IyNBAKEhQKEEZPUk1BVF9IMjY0UkdCMjQQ",
+            "EEKkAQoaY29tLmNha2VsYWIuYXJmbG93X2dycGMudjFCD1hyQ3B1SW1hZ2VQ",
+            "cm90b1ABogIDQ0FYqgIWQ2FrZUxhYi5BUkZsb3cuR3JwYy5WMcoCFUNha2Vs",
+            "YWJcQXJmbG93R3JwY1xWMeICIUNha2VsYWJcQXJmbG93R3JwY1xWMVxHUEJN",
+            "ZXRhZGF0YeoCF0Nha2VsYWI6OkFyZmxvd0dycGM6OlYxYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::CakeLab.ARFlow.Grpc.V1.Vector2IntReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -375,14 +378,21 @@ namespace CakeLab.ARFlow.Grpc.V1 {
         /// </summary>
         [pbr::OriginalName("FORMAT_ANDROID_YUV_420_888")] AndroidYuv420888 = 1,
         [pbr::OriginalName("FORMAT_IOS_YP_CBCR_420_8BI_PLANAR_FULL_RANGE")] IosYpCbcr4208BiPlanarFullRange = 2,
+        [pbr::OriginalName("FORMAT_ONECOMPONENT8")] Onecomponent8 = 3,
         /// <summary>
-        /// @exclude FORMAT_ONECOMPONENT8 = 3;
+        ///&#x2F; iOS
         /// </summary>
         [pbr::OriginalName("FORMAT_DEPTHFLOAT32")] Depthfloat32 = 4,
         /// <summary>
         ///&#x2F; Android
         /// </summary>
         [pbr::OriginalName("FORMAT_DEPTHUINT16")] Depthuint16 = 5,
+        [pbr::OriginalName("FORMAT_ONECOMPONENT32")] Onecomponent32 = 6,
+        [pbr::OriginalName("FORMAT_ARGB32")] Argb32 = 7,
+        [pbr::OriginalName("FORMAT_RGBA32")] Rgba32 = 8,
+        [pbr::OriginalName("FORMAT_BGRA32")] Bgra32 = 9,
+        [pbr::OriginalName("FORMAT_RGB24")] Rgb24 = 10,
+        [pbr::OriginalName("FORMAT_H264RGB24")] H264Rgb24 = 16,
       }
 
       /// <summary>


### PR DESCRIPTION
# Resources
Google Doc: [link](https://docs.google.com/document/d/1-4FaCknmNw8dhEIq8WOmzN6JtMYplZ3HKvM7zlOaGkk/edit?tab=t.0)
Demo Video: [link](https://youtu.be/GQ4HMia2HMA)
# Description (Copied from google doc)
## How It Works
### Theory
H264 compression is one of the methods used in applications to quickly allow large amounts of data to be sent over a network with minimal loss. The data compression is lossy, but extremely efficient, which allows a much greater amount of information to be transmitted at a much lower cost. The algorithm works in a couple of steps. First, a frame is compressed into JPEG. Then, in future frames, the algorithm instead splits the image up into chunks called “macroblocks” as per the official documentation. These macroblocks are analyzed in the algorithm, and a “residual”, the difference between the current frame and previous frames, is found. Then the algorithm only transmits the differences. By exploiting that in reality a frame does not completely change every second, this allows for much greater throughput as it avoids resending data for parts of the image. As with all algorithms, it requires some processing power on both the encoder and decoder ends to understand the data. Our tests and code seek to both implement a demo of a working compression method using the existing v0.4 ARFlow server and API architecture to provide more insight into future design and implementation of the server, as well as the feasibility of this compression method for practical frame transmission in AR device testing.

### Practice
The way H264 was implemented in the current ARFlow server and APIs is extremely barebone. A lot of work needs to be done to have a full and clean implementation of transmission, decompression, and display of ARFrames of compressed data, which may contain multiple singleton pieces of data in a single chunk. Furthermore, there is some concern about introducing additional installation and dependency on ffmpeg. Therefore, we have opted to change as little of the 0.4 API and server as possible, as well as create a separate branch to keep this code as an example and separate from main development. The main objective of this is to simply provide a working demo for future development, and we highlight some potential needed changes in the explanation below.

Compression starts client side. We have created a Python implementation of a client that is able to utilize ffmpeg to transmit data. Once a session is entered with a client, the client creates a separate process for ffmpeg, two threads, and additional long-lasting/expensive objects (such as the OpenCV camera). The first thread manages the OpenCV camera, it records frames from the camera and writes them into the input pipe of the ffmpeg subprocess. The thread also writes to a separate variable, which keeps track of the approximate number of frames encoded. This number, along with the looptime, is needed server-side to provide a timestamp approximation. This approximation is needed due to the first big challenge with the current server implementation. ARFrames/Colorframes simply do not have the space to allocate for multiple timestamps, meaning it is impossible to transmit all the currently gathered timestamps of many frames. The second thread is needed due to some drawbacks with ffmpeg. Ffmeg tends to crash if its output pipe contains too much data; therefore, the second thread is needed to continuously read and store data in a separate buffer in the main client process instead. The read size is a constant number of bytes. However, it is important to note that because frames are compressed based on movement, and because movement varies, each frame is a different size, so the read size is quite small. The original, main thread is in charge of other (not yet implemented) data collection and transmission of chunks of data in frames to the server. The current default time interval for this batching is 2 seconds. When data needs to be transmitted, the client, under mutex, reads the currently stored array buffer, which contains 0, 1, or many frames, stores the data in a new frame, and clears the buffer. The approximate number of frames read is read from the appropriate variable as well. This leads to another challenge with the current API implementation. The implementation assumes YUV frame encoding with pixel stride and row stride along with a main buffer; however, RGB is currently used on the client. There is a need to change the protobuf API to instead allow for frames with different fields, potentially mimicking class inheritance using oneof. On the upside, however, the YUV implementation opens up two integer fields in the data not needed for the buffer of encoded RGB frames, so the approximate number of frames is stored then in the row stride field, while the loop time in milliseconds is stored in the pixel stride field. The timestamp of the ARFrame is set to the last timestamp of gathering, then the variable storing the timestamp is set to the current time. From here, transmission to the server is the same as other frames.

Serverside, a flurry of changes are utilized to push through a working state of decompression and display to rerun. First, when a new session is created, it creates multiple internal dictionaries for device-specific variables. These dictionaries are indexed by the device's UID. When the server receives an encoded Colorframe for the first time, which is currently specified with the integer 16 for the enum value, it creates a ffmpeg subprocess and two threads as well. On every ARframe, the server queues the approximate number of frames from the request, as well as the device timestamp at the start of the batching, are pushes them into queues specific to the device. The device intervals are also converted from milliseconds to seconds at this step. Finally, the main thread writes the chunk from the data into ffmpeg’s pipe. The first thread simply takes data from a queue of frames and sends the data to rerun. The thread approximates the timestamp with the formula current_time + num_frames_read_from_cur * cur_time_interval / num_frames_in_batch, where the current time is the time interval from the last ARFrame. Some protection is implemented to prevent frames from being assigned an incorrect time frame. The code simply blocks if the number of currently displayed frames has exceeded the possible amount in the batch until a new batch is received. Furthermore, ffmpeg decodes threads faster than they are input, so the stream speeds up, then stops, even with appropriate timestamps without a sleep statement. There is a sleep statement that fixes this issue at the bottom of SessionStream.rerun_writer. This sleep statement can be left out to showcase the full performance increase of the code. This code operates on delaying execution based on the approximate fps of the buffer; however, protection is built in to ensure that the code never sleeps too long and the queue endlessly fills. Occasionally, there are issues with frames being displayed too fast or too slow; this is an issue caused by the approximation of timestamps failing. With accurate timestamps, this problem can be easily addressed. The second thread is similar to the second thread in the client; it reads data from ffmpeg's output pipe. This time, the read size is known, as width and height are known from the data in the arframe. This size is assumed constant; changing frame size after ffmpeg has started is impossible, and stopping and restarting this process would likely mean a loss of data. Once a full frame is read, it is simply put in the device-specific queue to be read by the first thread.

Once the client exits the session, the client’s session runner class is called to terminate, and so is its main loop thread. The session runner’s termination is responsible for closing the ffmpeg process (by closing the pipe’s stdin and stdout) and closing the two threads on the client side.

The server only ends the session once a delete session has happened. However, when leaving a session the server will automatically close the ffmpeg process and threads for the device that left the session. Two functions in the session stream have been implemented to handle this behavior, and added in the appropriate locations in core.py.

### Changes
+added the python/client/ subdirectory that contains the Python client. The current basic CLI client is located in the clients directory in python/client. To run it, cd into python/client/ and run ```python -m clients.cli```
~changed SessionStream.__init__ to initialize various needed functions to run concurrent threads/processes for decoding chunked data
~changed SessionStream.save_color_frames to add support for RGB frames (currently under enum 10 in commented out protobuf code)
~changed SessionStream.save_color_frames to add support for compressed RGB frames (no enum assigned, assigned a value of 16)
+added SessionStream.decoder_thread, the thread code which reads data from ffmpegs pipe and stores it in a queue to be displayed by rerun
+added SessionStream.rerun_writer, the thread code which reads decoded frames and adds them to rerun as well as attempts to approximate their correct timestamp
+added SessionStream.remove_device for the ability to remove a device from a SessionStream when it leaves - utilized right now to terminate devices threads and ffmpeg process
+added SessionStream.terminate for final cleanup when a session is deleted
~changed core.py to add SessionStream.remove_device and SessionStream.terminate in their needed locations in DeleteSession and LeaveSession

### Takeaways
Major changes are needed to support the chunking of compressed data.
- The ARFlow API needs to be changed to allow support for chunked data
  - The Colorframe protobuffer needs to be changed to allow compressed data and multiple timestamps
  - Alternatively, a whole different API endpoint and structure may be needed
  - Overall, it is up to future implementation to determine how specifically this needs to be done to suit compression, single frame, and other needs of the project
 - The ARFlow server may need changes to support this data
   - Yiqin and Nikita discussed how the server might be changed in the future for the server to be a connector so that the structure goes from client/server to server-connector(ARflow)-server. This type of structure would likely be more friendly towards batched requests, such as those utilized with the h264 implementation.

## Results
Note, tested on a Mac Mini 
Processor: Apple M2 chip (8-core CPU, 10-core GPU)
RAM: 16GB Unified Memory
Storage: 512GB SSD 
Neural Engine: 16-core
Memory Bandwidth: 100GB/s

ARFlow uses H.264 video compression to efficiently stream camera frames from AR devices to servers. The compression tests evaluate how well this works in practice. We compared uncompressed RGB frames vs H.264-compressed frames at two common resolutions:
SD: 640x480 pixels
HD: 1920x1080 pixels

Massive bandwidth savings 
An over 90% reduction means ARFlow can stream HD video on standard WiFi/mobile networks

High quality maintained
PSNR scores above 54 dB indicate minimal visual quality loss
No performance penalty 
FPS actually improved slightly with compression

Real-time streaming might be feasible 
124 Mbps for HD is manageable on most networks

Overall, ARFlow's H.264 compression is highly effective, reducing bandwidth requirements by over 90% while maintaining excellent video quality and performance. This makes real-time AR data streaming practical on standard networks.


### Test Location in GitHub Repository

The ARFlow compression tests and related files are located in the following directory structure within the vedantsaran fork of the ARFlow repository ([https://github.com/vedantsaran/ARFlow/](https://github.com/vedantsaran/ARFlow/)). They are also included in this pull request in the python directory under h264_tests.
Main Test Files

python/benchmarks/simple_compression_test.py - Primary compression evaluation script
python/benchmarks/real_arflow_compression_test.py - Real ARFlow session monitoring test
python/benchmarks/simple_phone_monitor.py - Phone monitoring for compression analysis

### Test Results and Reports

(in Vedant's repository, in this PR they are found in python/h264_tests)
python/compression_test_20250629_160028.csv - CSV report from first test run
python/compression_test_20250629_160028.json - JSON report from first test run
python/compression_test_20250629_160414.csv - CSV report from second test run
python/compression_test_20250629_160414.json - JSON report from second test run

### Supporting Files

(in Vedant's repository, this PR only has working code and results, for understanding where results come from viewing his repository is highly encouraged)
python/benchmarks/generate_payload.py - Payload generation for testing scenarios
python/benchmarks/bench.sh - Benchmark execution script
python/benchmarks/analyze.sh - Analysis script for test results
Test Scenarios Directory
python/benchmarks/scenarios/ - Contains different test scenarios:
light/ - Light payload testing
heavy/ - Heavy payload testing
mixed/ - Mixed payload testing

### Key Results
Configuration          Bytes Sent       FPS          Bandwidth (Mbps)   PSNR (dB)       Compression Ratio	Bandwidth Reduction
SD Uncompressed  138.24MB        26.99       221.18                      N/A                 N/A                          N/A
SD Compressed      11.52MB          27.75       18.43                        54.93               0.2:1                         91.7%
HD Uncompressed  933.12MB       26.91       1492.99                    N/A                 N/A                           N/A
HD Compressed      77.76MB         27.43       124.42                      58.28               0.3:1                          91.7%

Bandwidth reduction: Over 91% for both SD and HD when using H.264 compression.
Video quality: PSNR remains high (54.93 dB for SD, 58.28 dB for HD), indicating minimal perceptual loss.
Performance: FPS is maintained or slightly improved with compression.